### PR TITLE
Dell BOSS controller HealthRollup

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -282,8 +282,11 @@ class RedfishMetricsCollector(object):
             else:
                 controller_name = 'unknown'
 
-            if 'Health' in controller_details['Status']:
+            # Dell BOSS cards use HealthRollup instead of Health
+            if 'HealthRollup' in controller_details['Status']:
                 # Cisco sometimes uses None as status for onboard controllers
+                controller_status = math.nan if controller_details['Status']['HealthRollup'] is None else self._status[controller_details['Status']['HealthRollup'].lower()]
+            elif 'Health' in controller_details['Status']:
                 controller_status = math.nan if controller_details['Status']['Health'] is None else self._status[controller_details['Status']['Health'].lower()]
             else:
                 logging.warning("Target {0}, Host {1}, Model {2}, Controller {3}: No health data found.".format(self._target, self._host,self._model, controller_name))


### PR DESCRIPTION
On Dells, traditionally the PERC/controller status is not "OK" if there is a degraded array.

On newer Dells with a BOSS card, this uses 'HealthRollup' instead. (Health will be "OK" even with a failed drive/degraded array). For example:

```
/redfish/v1/Systems/System.Embedded.1/Storage/AHCI.SL.6-1 | jq .Status
{
  "Health": "OK",
  "HealthRollup": "Warning",
  "State": "Enabled"
}
```

Think it makes sense to check for 'HealthRollup' and use this if it exists, otherwise fail back to 'Health' but open to suggestions.
