### PR TITLE
handle multiple systems urls

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -235,8 +235,12 @@ class RedfishMetricsCollector(object):
 
         power_states = {"off": 0, "on": 1}
         # Get the server info for the labels
-        self._systems_url = systems['Members'][0]['@odata.id']
-        server_info = self.connect_server(self._systems_url)
+        server_info = {}
+        for member in systems['Members']:
+            self._systems_url = member['@odata.id']
+            info = self.connect_server(self._systems_url)
+            if info:
+                server_info.update(info)
         if not server_info:
             return
         self.manufacturer = server_info['Manufacturer']


### PR DESCRIPTION
On our systems, redfish has multiple end points defined and `systems['Members'][0]['@odata.id']` doesn't collect all of the required fields. This causes the exporter to fail with:
```
redfish-exporter  | 2023-11-09 20:10:33 [FALCON] [ERROR] GET /firmware?job=redfish&target=[...IP trimmed...] => Traceback (most recent call last):
redfish-exporter  |   File "falcon/app.py", line 365, in falcon.app.App.__call__
redfish-exporter  |   File "/redfish_exporter/handler.py", line 107, in on_get
redfish-exporter  |     resp.body = generate_latest(registry)
redfish-exporter  |   File "/usr/local/lib/python3.10/dist-packages/prometheus_client/exposition.py", line 197, in generate_latest
redfish-exporter  |     for metric in registry.collect():
redfish-exporter  |   File "/redfish_exporter/collector.py", line 317, in collect
redfish-exporter  |     self.get_base_labels()
redfish-exporter  |   File "/redfish_exporter/collector.py", line 243, in get_base_labels
redfish-exporter  |     self.model = server_info['Model']
redfish-exporter  | KeyError: 'Model'
```
This PR fixes the problem for us by looping through all `systems_url`s to populate `server_info`.