### PR TITLE
Use local vars, not instance vars, in metricsHandler

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -32,19 +32,19 @@ class metricsHandler:
         self.metrics_type = metrics_type
 
     def on_get(self, req, resp):
-        self.target = req.get_param("target")
-        if not self.target:
+        target = req.get_param("target")
+        if not target:
             logging.error("No target parameter provided!")
             raise falcon.HTTPMissingParam("target")
 
-        logging.debug(f"Received Target: {self.target}")
+        logging.debug(f"Received Target: {target}")
 
-        self._job = req.get_param("job")
-        if not self._job:
-            logging.error(f"Target {self.target}: No job provided!")
+        job = req.get_param("job")
+        if not job:
+            logging.error(f"Target {target}: No job provided!")
             raise falcon.HTTPMissingParam("job")
 
-        logging.debug(f"Received Job: {self._job}")
+        logging.debug(f"Received Job: {job}")
 
         ip_re = re.compile(
             r"^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
@@ -52,47 +52,49 @@ class metricsHandler:
 
         resp.set_header("Content-Type", CONTENT_TYPE_LATEST)
 
-        if ip_re.match(self.target):
-            logging.debug(f"Target {self.target}: Target is an IP Address.")
+        if ip_re.match(target):
+            logging.debug(f"Target {target}: Target is an IP Address.")
             try:
-                host = socket.gethostbyaddr(self.target)[0]
+                host = socket.gethostbyaddr(target)[0]
                 if host:
-                    self.host = host
+                    target_host = host
+                else:
+                    target_host = target
             except socket.herror as err:
-                msg = f"Target {self.target}: Reverse DNS lookup failed: {err}"
+                msg = f"Target {target}: Reverse DNS lookup failed: {err}"
                 logging.error(msg)
                 raise falcon.HTTPInvalidParam(msg, "target")
         else:
-            logging.debug(f"Target {self.target}: Target is a hostname.")
-            self.host = self.target
+            logging.debug(f"Target {target}: Target is a hostname.")
+            target_host = target
             try:
-                target = socket.gethostbyname(self.host)
-                if target:
-                    self.target = target
+                resolved_target = socket.gethostbyname(target_host)
+                if resolved_target:
+                    target = resolved_target
             except socket.gaierror as err:
-                msg = f"Target {self.target}: DNS lookup failed: {err}"
+                msg = f"Target {target}: DNS lookup failed: {err}"
                 logging.error(msg)
                 raise falcon.HTTPInvalidParam(msg, "target")
 
-        usr_env_var = self._job.replace("-", "_").upper() + "_USERNAME"
-        pwd_env_var = self._job.replace("-", "_").upper() + "_PASSWORD"
+        usr_env_var = job.replace("-", "_").upper() + "_USERNAME"
+        pwd_env_var = job.replace("-", "_").upper() + "_PASSWORD"
         usr = os.getenv(usr_env_var, self._config.get("username"))
         pwd = os.getenv(pwd_env_var, self._config.get("password"))
 
         if not usr or not pwd:
-            msg = f"Target {self.target}: Unknown job provided or no user/password found in environment and config file: {self._job}"
+            msg = f"Target {target}: Unknown job provided or no user/password found in environment and config file: {job}"
             logging.error(msg)
             raise falcon.HTTPInvalidParam(msg, "job")
 
-        logging.debug(f"Target {self.target}: Using user {usr}")
+        logging.debug(f"Target {target}: Using user {usr}")
 
         with RedfishMetricsCollector(
             self._config,
-            target = self.target,
-            host = self.host,
-            usr = usr,
-            pwd = pwd, 
-            metrics_type = self.metrics_type
+            target=target,
+            host=target_host,
+            usr=usr,
+            pwd=pwd, 
+            metrics_type=self.metrics_type
         ) as registry:
 
             # open a session with the remote board
@@ -105,5 +107,5 @@ class metricsHandler:
 
             except Exception as err:
                 message = f"Exception: {traceback.format_exc()}"
-                logging.error(f"Target {self.target}: {message}")
+                logging.error(f"Target {target}: {message}")
                 raise falcon.HTTPBadRequest("Bad Request", message)


### PR DESCRIPTION
When Falcon starts up, it creates an individual instance of metricsHandler for each metric type:

```python
def falcon_app():
    api = falcon.API()
    api.add_route("/health", metricsHandler(config, metrics_type="health"))
```

The same metricsHandler instance is used for every `/health` request.

This, by itself, is not an issue. However, because the instance stores state (such as IP/hostname) in instances variables, these can get clobbered if we process multiple requests simultaneously.

By instance variables I mean usage of `self`:
```python
class metricsHandler:
    ...
    def on_get(self, req, resp):
        self.target = req.get_param("target")
```

Here is you can reproduce this.
First, let's add some logging to show the issue.
```diff
diff --git a/collector.py b/collector.py
index 32d29d9..e183ddc 100644
--- a/collector.py
+++ b/collector.py
@@ -20,6 +20,8 @@ class RedfishMetricsCollector(object):
        self.target = target
        self.host = host

+       logging.info(f"**** Initializing RedfishMetricsCollector for hostname {self.host} and IP {self.target}")
+
        self._username = usr
        self._password = pwd
```
```diff
diff --git a/handler.py b/handler.py
index b035449..1627ffc 100644
--- a/handler.py
+++ b/handler.py
@@ -33,6 +33,8 @@ class metricsHandler:
        self.metrics_type = metrics_type

    def on_get(self, req, resp):
+       logging.info(f"**** The id of this metricsHandler instance is {id(self)}")
+
        self.target = req.get_param("target")
        if not self.target:
            logging.error("No target parameter provided!")
@@ -87,6 +89,7 @@ class metricsHandler:
        logging.debug(f"{self.target}: Using user {usr}")

+      logging.info(f"**** Scraping {self.host}, the client asked for {req.get_param('target')}")
        with RedfishMetricsCollector(
            self._config,
            target = self.target,
```

I am going to use the following bash script to quickly make two requests against the exporter:
```bash
#!/bin/bash
idracs=("foo" "bar")
for idrac in "${idracs[@]}"; do
    curl "http://localhost:9229/health?target=${idrac}&job=redfish" -o "${idrac}_stats.txt" &
done
```

Now, let’s observe the logs:
```
handler.py:36 INFO  *** The id of this metricsHandler instance is 131570941555444
handler.py:36 INFO  *** The id of this metricsHandler instance is 131570941555444
handler.py:94 INFO  *** Scraping foo; the client asked for foo
handler.py:94 INFO  *** Scraping foo; the client asked for bar
collector.py:23 INFO  *** Initializing RedfishMetricsCollector for hostname foo and IP 10.0.0.3.
collector.py:23 INFO  *** Initializing RedfishMetricsCollector for hostname foo and IP 10.0.0.3.
```

We see a few things:
	•	Lines 1,2: Indeed, the very same metricsHandler instance processes both requests (this is evidenced by the id being identical). Again, this isn’t an issue unto itself; just saying it’s the same instance so we can’t use self safely.
	•	Lines 3,4: You can see that it scrapes foo even though the client asked for bar
	•	Lines 5,6: From collector.py, you can see that the collector is initialized for foo and IP 10.0.0.3 *twice* even though we had asked for bar on the second request.

fixes #9 