### PR TITLE
Bug KeyError crash when storage units omit the Drives key entirely

### DIFF
--- a/collectors/health_collector.py
+++ b/collectors/health_collector.py
@@ -88,7 +88,7 @@ class HealthCollector():
                 current_labels
             )
 
-            for disk in controller_data["Drives"]:
+            for disk in controller_data.get("Drives", []):
                 disk_data = self.col.connect_server(disk["@odata.id"])
                 if not disk_data:
                     continue


### PR DESCRIPTION
Bug fixes:
    - Fix KeyError crash when storage units omit the Drives key entirely

Tested against MSI CX271-S4056 with AMI MegaRAC BMC firmware 1.39
    (Redfish 1.15.1).