### PR TITLE
get_base_labels() termination conditions modified. 

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -395,15 +395,22 @@ class RedfishMetricsCollector:
         links = server_info.get('Links', {})
         chassis_list = links.get('Chassis', [])
         managed_by_list = links.get('ManagedBy', [])
-        if chassis_list and managed_by_list:
+
+        if chassis_list:
             if isinstance(chassis_list[0], str):
                 self.urls['Chassis'] = chassis_list[0]
-                self.urls['ManagedBy'] = managed_by_list[0]
             else:
                 self.urls['Chassis'] = chassis_list[0]['@odata.id']
-                self.urls['ManagedBy'] = managed_by_list[0]['@odata.id']
+
+            if managed_by_list:
+                if isinstance(managed_by_list[0], str):
+                    self.urls['ManagedBy'] = managed_by_list[0]
+                else:
+                    self.urls['ManagedBy'] = managed_by_list[0]['@odata.id']
+            else:
+                logging.warning("Target %s: No ManagedBy links found on server %s!", self.target, self.host)
         else:
-            logging.warning("Target %s: No Chassis/ManagedBy links found on server %s!", self.target, self.host)
+            logging.warning("Target %s: No Chassis links found on server %s!", self.target, self.host)
             return
 
         self.get_chassis_urls()


### PR DESCRIPTION
In get_base_labels() in collector.py missing ManagedBy and Chassis links both lead to function termination, even though the first one is not needed. Modified the missing-link detection such that only the Chassis link is a strict requirement.

Some vendors don't supply the ManagedBy link but do supply Chassis. 