### PR TITLE
Handle missing MemoryDeviceType in DIMM info

### DIFF
--- a/collectors/health_collector.py
+++ b/collectors/health_collector.py
@@ -446,7 +446,7 @@ class HealthCollector():
             "device_name": dimm_info["Name"],
             "dimm_capacity": str(dimm_info["CapacityMiB"]),
             "dimm_speed": str(dimm_info.get("OperatingSpeedMhz", "unknown")),
-            "dimm_type": dimm_info["MemoryDeviceType"],
+            "dimm_type": dimm_info.get("MemoryDeviceType", "unknown"),
             "device_manufacturer": dimm_info.get("Manufacturer", "N/A"),
             "id": dimm_info.get("Id") or "unknown",
             "serial": dimm_info.get("SerialNumber") or "n/a",


### PR DESCRIPTION
MemoryDeviceType is not a required property in the Redfish Memory schema, and DGX systems do not return it.