### PR TITLE
Set an unknown serial number so .replace() doesn't fail

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -371,6 +371,9 @@ class RedfishMetricsCollector:
         else:
             self.serial = server_info.get('SerialNumber', 'unknown')
 
+        if self.serial is None:
+            self.serial = 'unknown'
+
         self.labels.update(
             {
                 "host": self.host,


### PR DESCRIPTION
Hi,
My Supermicro X13SRA-TF sends a null back for serial, which becomes a python None, and then there's some later failure when stuff tries to .replace(). With this, I can scrape my supermicro. Thanks.